### PR TITLE
Configure django plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Currently the following plugins are supported:
 
 ### Using pylint-django
 
-According to the [latest pylint-django docs](https://github.com/PyCQA/pylint-django#usage) it's required to set Django settigns module according to the project. If you have your settings module at root level you should do nothing, but if that's not the case then you need to declare your settings module in `.codeclimate.yml` as shown below.
+According to the [latest pylint-django docs](https://github.com/PyCQA/pylint-django#usage) it's required to set Django settings module according to the project. If you have your settings module at root level you should do nothing, but if that's not the case then you need to declare your settings module in `.codeclimate.yml` as shown below.
 
 ```
 engines:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ engines:
     enabled: true
     plugins:
       - django
-    settings_module: mymodule.settings
+    django_settings_module: mymodule.settings
 ```
 
 We welcome PRs adding support for other plugins.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Currently the following plugins are supported:
 - [pylint-celery](https://github.com/PyCQA/pylint-celery)
 - [pylint-quotes](https://github.com/edaniszewski/pylint-quotes)
 
+### Using pylint-django
+
+According to the [latest pylint-django docs](https://github.com/PyCQA/pylint-django#usage) it's required to set Django settigns module according to the project. If you have your settings module at root level you should do nothing, but if that's not the case then you need to declare your settings module in `.codeclimate.yml` as shown below.
+
+```
+engines:
+  pylint:
+    enabled: true
+    plugins:
+      - django
+    settings_module: mymodule.settings
+```
+
 We welcome PRs adding support for other plugins.
 
 ### Need help?

--- a/codeclimate-pylint
+++ b/codeclimate-pylint
@@ -32,10 +32,14 @@ for path in include_paths:
         parameters.append(path)
 
 plugins_config = config.get('plugins', [])
+settings_module = config.get('settings_module')
 if plugins_config:
     plugin_names = map(lambda plugin: 'pylint_{}'.format(plugin), plugins_config)
     parameters.append('--load-plugins=' + ','.join(plugin_names))
     if 'django' in plugins_config:
-        parameters.append('--django-settings-module=code.settings')
+        if settings_module != None:
+            parameters.append('--django-settings-module=code.' + settings_module)
+        else:
+            parameters.append('--django-settings-module=code.settings')
 
 Run(parameters, reporter=CodeClimateReporter(), do_exit=False)

--- a/codeclimate-pylint
+++ b/codeclimate-pylint
@@ -35,5 +35,7 @@ plugins_config = config.get('plugins', [])
 if plugins_config:
     plugin_names = map(lambda plugin: 'pylint_{}'.format(plugin), plugins_config)
     parameters.append('--load-plugins=' + ','.join(plugin_names))
+    if 'django' in plugins_config:
+        parameters.append('--django-settings-module=code.settings')
 
 Run(parameters, reporter=CodeClimateReporter(), do_exit=False)

--- a/codeclimate-pylint
+++ b/codeclimate-pylint
@@ -32,13 +32,13 @@ for path in include_paths:
         parameters.append(path)
 
 plugins_config = config.get('plugins', [])
-settings_module = config.get('settings_module')
+django_settings_module = config.get('django_settings_module')
 if plugins_config:
     plugin_names = map(lambda plugin: 'pylint_{}'.format(plugin), plugins_config)
     parameters.append('--load-plugins=' + ','.join(plugin_names))
     if 'django' in plugins_config:
-        if settings_module != None:
-            parameters.append('--django-settings-module=code.' + settings_module)
+        if django_settings_module != None:
+            parameters.append('--django-settings-module=code.' + django_settings_module)
         else:
             parameters.append('--django-settings-module=code.settings')
 


### PR DESCRIPTION
Currently the django plugin is not working correctly. The reason for this is that dependabot updates have been merged without updating django configuration according to the version. 

From django's plugin [usage documenation](https://github.com/PyCQA/pylint-django#usage):

> Usage
> -----
> 
> 
> Ensure ``pylint-django`` is installed and on your path. In order to access some
> of the internal Django features to improve pylint inspections, you should also
> provide a Django settings module appropriate to your project. This can be done
> either with an environment variable::
> 
>     DJANGO_SETTINGS_MODULE=your.app.settings pylint --load-plugins pylint_django [..other options..] <path_to_your_sources>
> 
> Alternatively, this can be passed in as a commandline flag::
> 
>     pylint --load-plugins pylint_django --django-settings-module=your.app.settings [..other options..] <path_to_your_sources>
> 
> If you do not configure Django, default settings will be used but this will not include, for
> example, which applications to include in `INSTALLED_APPS` and so the linting and type inference
> will be less accurate. It is recommended to specify a settings module.

Since our use case consists for running the plugin in different projects the second configuration options seems like a better fit.